### PR TITLE
Upgrade Python package versions

### DIFF
--- a/ggv2-deploy-cloud/artifacts/install.sh
+++ b/ggv2-deploy-cloud/artifacts/install.sh
@@ -10,6 +10,8 @@ echo $thispath
 cd $thispath
 echo '====== Install Dependencies ======' 
 
+[ -d "gcv" ] && rm -rf gcv
+
 python3 -m venv gcv
 source gcv/bin/activate
 

--- a/ggv2-deploy-cloud/artifacts/install.sh
+++ b/ggv2-deploy-cloud/artifacts/install.sh
@@ -10,9 +10,7 @@ echo $thispath
 cd $thispath
 echo '====== Install Dependencies ======' 
 
-[ -d "gcv" ] && rm -rf gcv
-
-python3 -m venv gcv
+python3 -m venv
 source gcv/bin/activate
 
 pip3 install pip --upgrade

--- a/ggv2-deploy-cloud/artifacts/requirements.txt
+++ b/ggv2-deploy-cloud/artifacts/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 Cython
-numpy==1.19.5
-opencv-python-headless==4.5.3.56
+numpy==1.21.2
+opencv-python-headless==4.8.0.74
 dlr==1.8.0
 awsiotsdk


### PR DESCRIPTION
*Issue #, if available:* `-`
  - Resolved package dependency issues when running `install.sh` with Python 3.10 on the Cloud9 Ubuntu Server 22.04 LTS platform. 

*Description of changes:*
  - `numpy` version upgraded from `1.19.5` to `1.21.2`.
  -  `opencv-python-headless` version upgraded from `4.5.3.56`to `4.8.0.74`.

*References:*
- opencv-python-headless [`pyproject.toml`](https://github.com/opencv/opencv-python/blob/3c972caa570a7ad8974ab6027cff8c511009fdda/pyproject.toml)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

C.C @daekeun-ml @sehyul @kjhyuok